### PR TITLE
Use package.json to get startup info

### DIFF
--- a/Common/Util.cpp
+++ b/Common/Util.cpp
@@ -110,13 +110,14 @@ namespace nodeuwputil
 			for (size_t i = 0; i < args.length(); i++) {
 
 				wchar_t c = args[i];
-				if (c == ' ') {
+				if (c == ' ') 
+				{
 					insert = true;
 				}
 				else if (c == '\"') 
 				{
 					i++;
-					while (args[i] != '\"')
+					while (args[i] != '\"' && i < args.size())
 					{ 
 						arg += args[i];
 						i++; 
@@ -124,7 +125,8 @@ namespace nodeuwputil
 					i++;
 					insert = true;
 				}
-				else {
+				else 
+				{
 					arg += args[i];
 				}
 

--- a/Common/Util.h
+++ b/Common/Util.h
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #include <vector>
 
 using namespace std;
+using namespace Platform;
 using namespace Windows::Storage;
 using namespace Windows::Data::Xml::Dom;
 
@@ -39,6 +40,9 @@ namespace nodeuwputil
 
 	void PopulateArgsVector(vector<shared_ptr<char>> &argVector,
 		XmlNodeList^ argNodes, bool isStartupScript, bool* const &useLogger);
+
+	void PopulateArgsVector(vector<shared_ptr<char>> &argVector,
+		String^ startStr, bool* const &useLogger);
 
 	void CopyFolderSync(StorageFolder^ source, StorageFolder^ destination);
 }

--- a/Common/Util.h
+++ b/Common/Util.h
@@ -39,10 +39,7 @@ namespace nodeuwputil
 	shared_ptr<wchar_t> CharToWChar(const char* str, int strSize);
 
 	void PopulateArgsVector(vector<shared_ptr<char>> &argVector,
-		XmlNodeList^ argNodes, bool isStartupScript, bool* const &useLogger);
-
-	void PopulateArgsVector(vector<shared_ptr<char>> &argVector,
-		String^ startStr, bool* const &useLogger);
+		String^ startStr, bool &useLogger);
 
 	void CopyFolderSync(StorageFolder^ source, StorageFolder^ destination);
 }

--- a/Headed/nodeuwpui/Package.appxmanifest
+++ b/Headed/nodeuwpui/Package.appxmanifest
@@ -27,6 +27,7 @@
               <uap:FileType>.testinfo</uap:FileType>
               <uap:FileType>.xml</uap:FileType>
               <uap:FileType>.js</uap:FileType>
+              <uap:FileType>.json</uap:FileType>
             </uap:SupportedFileTypes>
           </uap:FileTypeAssociation>
         </uap:Extension>

--- a/Headed/nodeuwpui/nodeuwpui.vcxproj
+++ b/Headed/nodeuwpui/nodeuwpui.vcxproj
@@ -7,8 +7,8 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.14361.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.10586.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -236,9 +236,6 @@
     <AppxManifest Include="Package.appxmanifest">
       <SubType>Designer</SubType>
     </AppxManifest>
-    <None Include="$(NODE_DIR)\Release\node.dll">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
     <None Include="nodeuwpui_TemporaryKey.pfx" />
   </ItemGroup>
   <ItemGroup>

--- a/Headless/nodeuwp/StartupTask.cpp
+++ b/Headless/nodeuwp/StartupTask.cpp
@@ -88,16 +88,18 @@ void StartupTask::Run(IBackgroundTaskInstance^ taskInstance)
 				argv.get()[i] = (argumentVector[i]).get();
 			}
 
+			int exitCode = 0;
 			if (!useLogger)
 			{
-				node::Start(argc, argv.get());
+				exitCode = node::Start(argc, argv.get());
 			}
 			else
 			{
-				node::Start(argc, argv.get(), &Logger::GetInstance("nodeuwp.log"));
+				exitCode = node::Start(argc, argv.get(), &Logger::GetInstance("nodeuwp.log"));
 			}
 
 			deferral->Complete();
+			std::exit(exitCode);
 		});
 	});
 }

--- a/Headless/nodeuwp/StartupTask.cpp
+++ b/Headless/nodeuwp/StartupTask.cpp
@@ -78,7 +78,7 @@ void StartupTask::Run(IBackgroundTaskInstance^ taskInstance)
 			}
 			if (nullptr != startStr)
 			{
-				PopulateArgsVector(argumentVector, startStr, &useLogger);
+				PopulateArgsVector(argumentVector, startStr, useLogger);
 			}
 			// If 'scripts' isn't found check for 'main'
 			else
@@ -96,7 +96,7 @@ void StartupTask::Run(IBackgroundTaskInstance^ taskInstance)
 
 				if (nullptr != startStr)
 				{
-					PopulateArgsVector(argumentVector, startStr, &useLogger);
+					PopulateArgsVector(argumentVector, startStr, useLogger);
 				}
 				else
 				{

--- a/Headless/nodeuwp/StartupTask.cpp
+++ b/Headless/nodeuwp/StartupTask.cpp
@@ -63,11 +63,12 @@ void StartupTask::Run(IBackgroundTaskInstance^ taskInstance)
 
 			JsonObject^ jsonObj = JsonObject::Parse(jsonStr);
 
-			// First check 'main' for the script to start
+			// First check 'scripts' for the script to start
 			String^ startStr;
 			try
 			{
-				startStr = jsonObj->GetNamedString("main");
+				JsonObject^ scriptsObj = jsonObj->GetNamedObject("scripts");
+				startStr = scriptsObj->GetNamedString("start");
 			}
 			catch (Exception^ e) {
 				if (e->HResult != WEB_E_JSON_VALUE_NOT_FOUND)
@@ -75,18 +76,16 @@ void StartupTask::Run(IBackgroundTaskInstance^ taskInstance)
 					throw;
 				}
 			}
-
 			if (nullptr != startStr)
 			{
 				PopulateArgsVector(argumentVector, startStr, &useLogger);
 			}
-			// If there was no 'main' check for a 'scripts' object
+			// If 'scripts' isn't found check for 'main'
 			else
 			{
 				try
 				{
-					jsonObj = jsonObj->GetNamedObject("scripts");
-					startStr = jsonObj->GetNamedString("start");
+					startStr = jsonObj->GetNamedString("main");
 				}
 				catch (Exception^ e) {
 					if (e->HResult != WEB_E_JSON_VALUE_NOT_FOUND)

--- a/Headless/nodeuwp/nodeuwp.vcxproj
+++ b/Headless/nodeuwp/nodeuwp.vcxproj
@@ -41,8 +41,8 @@
     <PackageCertificateKeyFile>nodeuwp_TemporaryKey.pfx</PackageCertificateKeyFile>
     <ContainsStartupTask>true</ContainsStartupTask>
     <ProjectName>nodeuwp</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.10586.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -266,7 +266,13 @@
     <ClCompile Include="StartupTask.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\..\..\my_node\Debug\node.dll">
+      <DeploymentContent>true</DeploymentContent>
+    </None>
     <None Include="nodeuwp_TemporaryKey.pfx" />
+    <None Include="package.json">
+      <DeploymentContent>true</DeploymentContent>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <SDKReference Include="WindowsIoT, Version=10.0.10586.0" />

--- a/Test/run.ps1
+++ b/Test/run.ps1
@@ -20,7 +20,7 @@
 # 3. Copy tests to appx storage folder
 # 4. Reads .testinfo in documents folder to get list of tests to run
 # 5. For each test:
-#      a. Create startupinfo.xml file which contains arguments for node
+#      a. Create package.json file which contains arguments for node
 #      b. Run node
 # 6. Uninstall appx
 
@@ -132,13 +132,13 @@ if([string]::IsNullOrEmpty($appl)) {
   Exit
 }
 
-$appxFolderPath = $app
+$appxFolderPath = $app.TrimEnd('\')
 $testSrcPath = $test
 $appLauncherPath = $appl
 
 # Install appx certificate to TrustedPeople
 $cerFileName = Get-Childitem -path $appxFolderPath -filter *.cer
-$certPath = $appxFolderPath + $cerFileName
+$certPath = $appxFolderPath + '\' + $cerFileName
 Import-Certificate -FilePath $certPath -CertStoreLocation cert:\LocalMachine\TrustedPeople
 
 
@@ -159,7 +159,7 @@ Copy-Item -Path $testSrcPath -Destination $appStoragePath -Recurse -Force
 
 
 $docsFolder = [environment]::getfolderpath("mydocuments")
-$startupinfoFileName = "\startupinfo.xml"
+$startupinfoFileName = "\package.json"
 
 $testInfoFileName = Get-Childitem -path $docsFolder -filter nodeuwp.testinfo
 $testInfoPath = $docsFolder + "\" + $testInfoFileName
@@ -180,20 +180,7 @@ Param ($msg)
 
 function Save-StartupInfo {
 Param ($t, $f)
-  $xmlDoc = New-Object System.Xml.XmlDocument
-
-  $StartupInfo = $xmlDoc.CreateElement("StartupInfo")
-  $xmlDoc.appendChild($StartupInfo) | out-null
-  $Script = $xmlDoc.CreateElement("Script")
-  $Script.AppendChild($xmlDoc.CreateTextNode($t)) | out-null
-  $StartupInfo.AppendChild($Script) | out-null
-  
-  $NodeOptions = $xmlDoc.CreateElement("NodeOptions")
-  $StartupInfo.AppendChild($NodeOptions) | out-null
-  $ScriptArgs = $xmlDoc.CreateElement("ScriptArgs")
-  $StartupInfo.AppendChild($ScriptArgs) | out-null
-
-  $xmlDoc.Save($f)
+  @{name="node-uwp-test";version="0.0.0";main=$t} | ConvertTo-Json -Compress | Out-File $f
 }
 
 function Run-Tests {


### PR DESCRIPTION
This change removes the use of startupinfo.xml as the file used for getting startup info (node args, script to run, script args). Instead we'll use the package.json file for this. The file will be expected to have a 'scripts' object with a 'start' property that will contain the startup info. This works now with the node console app (e.g. if someone runs "npm start"). If there's no script object then the 'main' object is used to just get the script to run (main is secondary since this is the entry point when the package.json is being used in an npm package).
Related to https://github.com/ms-iot/ntvsiot/pull/105 (corresponding change in the NTVS IoT Extension).