### PR TITLE
Add missing node.dll to headed app and fix minor issue in test script

### DIFF
--- a/Headed/nodeuwpui/nodeuwpui.vcxproj
+++ b/Headed/nodeuwpui/nodeuwpui.vcxproj
@@ -236,6 +236,9 @@
     <AppxManifest Include="Package.appxmanifest">
       <SubType>Designer</SubType>
     </AppxManifest>
+    <None Include="$(NODE_DIR)\$(Configuration)\node.dll">
+      <DeploymentContent>true</DeploymentContent>
+    </None>
     <None Include="nodeuwpui_TemporaryKey.pfx" />
   </ItemGroup>
   <ItemGroup>

--- a/Test/run.ps1
+++ b/Test/run.ps1
@@ -133,12 +133,13 @@ if([string]::IsNullOrEmpty($appl)) {
 }
 
 $appxFolderPath = $app.TrimEnd('\')
+$appxFolderPath += '\'
 $testSrcPath = $test
 $appLauncherPath = $appl
 
 # Install appx certificate to TrustedPeople
 $cerFileName = Get-Childitem -path $appxFolderPath -filter *.cer
-$certPath = $appxFolderPath + '\' + $cerFileName
+$certPath = $appxFolderPath + $cerFileName
 Import-Certificate -FilePath $certPath -CertStoreLocation cert:\LocalMachine\TrustedPeople
 
 


### PR DESCRIPTION
* After a clean clone I realized that I had only included node.dll to
the project locally.
* The change to the script is to allow the path argument to either have
a trailing slash or not.