### PR TITLE
Extract node_modules folder to local storage

### DIFF
--- a/Common/Util.cpp
+++ b/Common/Util.cpp
@@ -27,6 +27,11 @@ THE SOFTWARE.
 #include <Windows.h>
 #include <filesystem>
 #include <sstream>
+#include "unzip.h"
+#include <direct.h>
+
+#define WRITEBUFFERSIZE 8192
+#define NODE_MODULE_MAX_PATH 1024 
 
 using namespace Platform;
 using namespace std::tr2::sys;
@@ -175,5 +180,215 @@ namespace nodeuwputil
 		path to(destination->Path->Data());
 		copy_options opts = copy_options::recursive | copy_options::update_existing;
 		copy(from, to, opts);
+	}
+
+    // Based on https://github.com/madler/zlib/blob/master/contrib/minizip/miniunz.c#L138
+	void MakePath(const char *newdir)
+	{
+		char *buffer;
+		char *p;
+		int  len = (int)strlen(newdir);
+		int err;
+
+		if (len <= 0)
+		{
+			return;
+		}
+
+		buffer = (char*)malloc(len + 1);
+		if (buffer == NULL)
+		{
+			throw ref new ::Platform::Exception(HRESULT_FROM_WIN32(ERROR_OUTOFMEMORY), 
+				L"nodeuwputil::MakePath Error allocating memory");
+		}
+		strcpy_s(buffer, (len + 1), newdir);
+
+		if (buffer[len - 1] == '/') {
+			buffer[len - 1] = '\0';
+		}
+		
+		err = _mkdir(buffer);
+		if (err == 0)
+		{
+			return;
+		}
+
+		p = buffer + 1;
+		while (1)
+		{
+			char hold;
+
+			while (*p && *p != '\\' && *p != '/')
+				p++;
+			hold = *p;
+			*p = 0;
+			err = _mkdir(buffer);
+			if (err == -1 && (errno == ENOENT))
+			{
+				throw ref new ::Platform::Exception(HRESULT_FROM_WIN32(errno), L"nodeuwputil::MakePath _mkdir failed. Directory: " +
+					ref new String(CharToWChar(buffer, (len + 1)).get()));
+			}
+			if (hold == 0)
+				break;
+			*p++ = hold;
+		}
+		free(buffer);
+	}
+
+	// Based on https://github.com/ms-iot/node/blob/chakra-uwp/deps/zlib/contrib/minizip/miniunz.c#L312
+	void DoExtractCurrentfile(unzFile uf, char* dest)
+	{
+		char filename_inzip[NODE_MODULE_MAX_PATH];
+		char* filename_withoutpath;
+		char* p;
+		FILE *fout = NULL;
+		void* buf;
+		uInt size_buf;
+		unz_file_info64 file_info;
+		uLong ratio = 0;
+
+		int err = unzGetCurrentFileInfo64(uf, &file_info, filename_inzip, sizeof(filename_inzip), NULL, 0, NULL, 0);
+		if (err != UNZ_OK)
+		{
+			throw ref new ::Platform::Exception(err, L"nodeuwputil::DoExtractCurrentfile unzGetCurrentFileInfo64 failed. Filename: " + 
+				ref new String(CharToWChar(filename_inzip, sizeof(filename_inzip)).get()));
+		}
+
+		// Prepend the destination to the path (filename_inzip)
+		char temp[NODE_MODULE_MAX_PATH];
+		strcpy_s(temp, NODE_MODULE_MAX_PATH, filename_inzip);
+		strcpy_s(filename_inzip, NODE_MODULE_MAX_PATH, dest);
+		strcat_s(filename_inzip, NODE_MODULE_MAX_PATH, "\\");
+		strcat_s(filename_inzip, NODE_MODULE_MAX_PATH, temp);
+
+		size_buf = WRITEBUFFERSIZE;
+		buf = (void*)malloc(size_buf);
+		if (buf == NULL)
+		{
+			throw ref new ::Platform::Exception(err, L"nodeuwputil::DoExtractCurrentfile Error allocating memory");
+		}
+
+		p = filename_withoutpath = filename_inzip;
+		while ((*p) != '\0')
+		{
+			if (((*p) == '/') || ((*p) == '\\'))
+			{
+				filename_withoutpath = p + 1;
+			}
+			p++;
+		}
+
+		if ((*filename_withoutpath) == '\0')
+		{
+			err = _mkdir(filename_inzip);
+			if (0 != err)
+			{
+				throw ref new ::Platform::Exception(err, L"nodeuwputil::DoExtractCurrentfile _mkdir failed. Directory: " +
+					ref new String(CharToWChar(filename_inzip, sizeof(filename_inzip)).get()));
+			}
+		}
+		else
+		{
+			const char* write_filename = filename_inzip;
+
+			if (err == UNZ_OK)
+			{
+				fopen_s(&fout, write_filename, "wb");
+				/* some zipfile don't contain directory alone before file */
+				if ((fout == NULL) && (filename_withoutpath != (char*)filename_inzip))
+				{
+					char c = *(filename_withoutpath - 1);
+					*(filename_withoutpath - 1) = '\0';
+					MakePath(write_filename);
+					*(filename_withoutpath - 1) = c;
+					fopen_s(&fout, write_filename, "wb");
+				}
+
+				if (fout == NULL)
+				{
+					throw ref new ::Platform::Exception(err, L"nodeuwputil::DoExtractCurrentfile fopen_s failed. Filename: " +
+						ref new String(CharToWChar(write_filename, sizeof(filename_inzip)).get()));
+				}
+			}
+
+			// Needs to be called even when zip has no password
+			err = unzOpenCurrentFilePassword(uf, 0);
+			if (err != UNZ_OK)
+			{
+				throw ref new ::Platform::Exception(err, L"nodeuwputil::DoExtractCurrentfile unzOpenCurrentFilePassword failed");
+			}
+
+			if (fout != NULL)
+			{
+				do
+				{
+					err = unzReadCurrentFile(uf, buf, size_buf);
+					if (err < 0)
+					{
+						throw ref new ::Platform::Exception(err, L"nodeuwputil::DoExtractCurrentfile unzReadCurrentFile failed. Filename: " +
+							ref new String(CharToWChar(write_filename, sizeof(filename_inzip)).get()));
+					}
+					if (err > 0)
+					{
+						// TODO: See if there would be improvement by only overwritting if timestamp has changed
+						if (fwrite(buf, err, 1, fout) != 1)
+						{
+							throw ref new ::Platform::Exception(errno, L"nodeuwputil::DoExtractCurrentfile fwrite failed. Filename: " +
+								ref new String(CharToWChar(write_filename, sizeof(filename_inzip)).get()));
+						}
+					}
+				} while (err > 0);
+
+				fclose(fout);
+			}
+
+			unzCloseCurrentFile(uf);
+		}
+
+		free(buf);
+	}
+
+	// Based on https://github.com/ms-iot/node/blob/chakra-uwp/deps/zlib/contrib/minizip/miniunz.c#L475
+	void DoExtract(unzFile uf, char* dest)
+	{
+		unz_global_info64 gi;
+
+		int err = unzGetGlobalInfo64(uf, &gi);
+		if (err != UNZ_OK)
+		{
+			throw ref new ::Platform::Exception(err, L"nodeuwputil::DoExtract unzGetGlobalInfo failed");
+		}
+
+		for (uLong i = 0; i < gi.number_entry; i++)
+		{
+			DoExtractCurrentfile(uf, dest);
+
+			if ((i + 1) < gi.number_entry)
+			{
+				err = unzGoToNextFile(uf);
+				if (err != UNZ_OK)
+				{
+					throw ref new ::Platform::Exception(err, L"nodeuwputil::DoExtract unzGoToNextFile failed");
+				}
+			}
+		}
+	}
+
+
+	void Extract(StorageFile^ zipFile, String^ destination)
+	{
+		shared_ptr<char> zipFileCharStr = WCharToChar(zipFile->Path->Data(), zipFile->Path->Length());
+		unzFile uf = unzOpen64(zipFileCharStr.get());
+
+		if (uf)
+		{
+			DoExtract(uf, WCharToChar(destination->Data(), destination->Length()).get());
+
+			unzClose(uf);
+		}
+		else
+		{
+			throw ref new ::Platform::Exception(ERROR_INVALID_PARAMETER, L"nodeuwputil::Extract Invalid zip file");
+		}
 	}
 }

--- a/Common/Util.h
+++ b/Common/Util.h
@@ -44,4 +44,6 @@ namespace nodeuwputil
 	void CopyFolderSync(StorageFolder^ source, StorageFolder^ destination);
 
 	void Extract(StorageFile^ zipFile, String^ destination);
+
+	bool ModuleUpdateRequired();
 }

--- a/Common/Util.h
+++ b/Common/Util.h
@@ -42,4 +42,6 @@ namespace nodeuwputil
 		String^ startStr, bool &useLogger);
 
 	void CopyFolderSync(StorageFolder^ source, StorageFolder^ destination);
+
+	void Extract(StorageFile^ zipFile, String^ destination);
 }

--- a/Headless/nodeuwp/StartupTask.cpp
+++ b/Headless/nodeuwp/StartupTask.cpp
@@ -50,6 +50,10 @@ void StartupTask::Run(IBackgroundTaskInstance^ taskInstance)
 	// or folders relative to the location of the starup JavaScript file
 	CopyFolderSync(appFolder, localFolder);
 
+	// Extract node_modules folder into local storage folder
+	StorageFile^ zipFile = create_task(localFolder->GetFileAsync("node_modules.zip")).get();
+	Extract(zipFile, localFolder->Path + "\\node_modules");
+
 	BackgroundTaskDeferral^ deferral = taskInstance->GetDeferral();
 
 	create_task(localFolder->GetFileAsync("package.json")).then([=](StorageFile^ storageFile)

--- a/Headless/nodeuwp/StartupTask.cpp
+++ b/Headless/nodeuwp/StartupTask.cpp
@@ -46,16 +46,19 @@ void StartupTask::Run(IBackgroundTaskInstance^ taskInstance)
 	StorageFolder^ appFolder = Windows::ApplicationModel::Package::Current->InstalledLocation;
 	StorageFolder^ localFolder = ApplicationData::Current->LocalFolder;
 
+	// Extract node_modules folder into local storage folder
+	if (ModuleUpdateRequired())
+	{
+		StorageFile^ zipFile = create_task(appFolder->GetFileAsync("node_modules.zip")).get();
+		Extract(zipFile, localFolder->Path + "\\node_modules");
+	}
+
 	// Copy files to this applications local storage so that node can read/write to files
 	// or folders relative to the location of the starup JavaScript file
 	CopyFolderSync(appFolder, localFolder);
 
-	// Extract node_modules folder into local storage folder
-	StorageFile^ zipFile = create_task(localFolder->GetFileAsync("node_modules.zip")).get();
-	Extract(zipFile, localFolder->Path + "\\node_modules");
-
 	BackgroundTaskDeferral^ deferral = taskInstance->GetDeferral();
-
+	
 	create_task(localFolder->GetFileAsync("package.json")).then([=](StorageFile^ storageFile)
 	{
 		create_task(FileIO::ReadTextAsync(storageFile)).then([=](String^ jsonStr)

--- a/Headless/nodeuwp/nodeuwp.vcxproj
+++ b/Headless/nodeuwp/nodeuwp.vcxproj
@@ -34,7 +34,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <ApplicationTypeRevision>8.2</ApplicationTypeRevision>
+    <ApplicationTypeRevision>10</ApplicationTypeRevision>
     <UseAppLocalVCLibs>true</UseAppLocalVCLibs>
     <AppxPackage>true</AppxPackage>
     <AppxPackageSigningEnabled>true</AppxPackageSigningEnabled>
@@ -129,12 +129,12 @@
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204</DisableSpecificWarnings>
-      <AdditionalIncludeDirectories>$(NODE_DIR)\src;$(NODE_DIR)\deps\chakrashim\include;$(NODE_DIR)\deps\logger\include;..\..\Common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(NODE_DIR)\src;$(NODE_DIR)\deps\zlib;$(NODE_DIR)\deps\zlib\contrib\minizip;$(NODE_DIR)\deps\chakrashim\include;$(NODE_DIR)\deps\logger\include;..\..\Common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>runtimeobject.lib;node.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(NODE_DIR)\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>runtimeobject.lib;node.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(NODE_DIR)\$(Configuration);$(NODE_DIR)\$(Configuration)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -146,14 +146,14 @@
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204</DisableSpecificWarnings>
-      <AdditionalIncludeDirectories>$(NODE_DIR)\src;$(NODE_DIR)\deps\chakrashim\include;$(NODE_DIR)\deps\logger\include;..\..\Common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(NODE_DIR)\src;$(NODE_DIR)\deps\zlib;$(NODE_DIR)\deps\zlib\contrib\minizip;$(NODE_DIR)\deps\chakrashim\include;$(NODE_DIR)\deps\logger\include;..\..\Common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>runtimeobject.lib;node.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>runtimeobject.lib;node.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
-      <AdditionalLibraryDirectories>$(NODE_DIR)\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(NODE_DIR)\$(Configuration);$(NODE_DIR)\$(Configuration)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>
       </IgnoreSpecificDefaultLibraries>
     </Link>
@@ -171,13 +171,13 @@
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204</DisableSpecificWarnings>
-      <AdditionalIncludeDirectories>$(NODE_DIR)\src;$(NODE_DIR)\deps\chakrashim\include;$(NODE_DIR)\deps\logger\include;..\..\Common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(NODE_DIR)\src;$(NODE_DIR)\deps\zlib;$(NODE_DIR)\deps\zlib\contrib\minizip;$(NODE_DIR)\deps\chakrashim\include;$(NODE_DIR)\deps\logger\include;..\..\Common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>runtimeobject.lib;node.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>runtimeobject.lib;node.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
-      <AdditionalLibraryDirectories>$(NODE_DIR)\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(NODE_DIR)\$(Configuration);$(NODE_DIR)\$(Configuration)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
@@ -189,13 +189,13 @@
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204</DisableSpecificWarnings>
-      <AdditionalIncludeDirectories>$(NODE_DIR)\src;$(NODE_DIR)\deps\chakrashim\include;$(NODE_DIR)\deps\logger\include;..\..\Common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(NODE_DIR)\src;$(NODE_DIR)\deps\zlib;$(NODE_DIR)\deps\zlib\contrib\minizip;$(NODE_DIR)\deps\chakrashim\include;$(NODE_DIR)\deps\logger\include;..\..\Common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>runtimeobject.lib;node.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>runtimeobject.lib;node.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
-      <AdditionalLibraryDirectories>$(NODE_DIR)\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(NODE_DIR)\$(Configuration);$(NODE_DIR)\$(Configuration)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -207,13 +207,13 @@
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204</DisableSpecificWarnings>
-      <AdditionalIncludeDirectories>$(NODE_DIR)\src;$(NODE_DIR)\deps\chakrashim\include;$(NODE_DIR)\deps\logger\include;..\..\Common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(NODE_DIR)\src;$(NODE_DIR)\deps\zlib;$(NODE_DIR)\deps\zlib\contrib\minizip;$(NODE_DIR)\deps\chakrashim\include;$(NODE_DIR)\deps\logger\include;..\..\Common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>runtimeobject.lib;node.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>runtimeobject.lib;node.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
-      <AdditionalLibraryDirectories>$(NODE_DIR)\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(NODE_DIR)\$(Configuration);$(NODE_DIR)\$(Configuration)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -225,13 +225,13 @@
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204</DisableSpecificWarnings>
-      <AdditionalIncludeDirectories>$(NODE_DIR)\src;$(NODE_DIR)\deps\chakrashim\include;$(NODE_DIR)\deps\logger\include;..\..\Common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(NODE_DIR)\src;$(NODE_DIR)\deps\zlib;$(NODE_DIR)\deps\zlib\contrib\minizip;$(NODE_DIR)\deps\chakrashim\include;$(NODE_DIR)\deps\logger\include;..\..\Common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>runtimeobject.lib;node.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>runtimeobject.lib;node.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
-      <AdditionalLibraryDirectories>$(NODE_DIR)\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(NODE_DIR)\$(Configuration);$(NODE_DIR)\$(Configuration)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -270,6 +270,9 @@
       <DeploymentContent>true</DeploymentContent>
     </None>
     <None Include="nodeuwp_TemporaryKey.pfx" />
+    <None Include="node_modules.zip">
+      <DeploymentContent>true</DeploymentContent>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <SDKReference Include="WindowsIoT, Version=10.0.10586.0" />

--- a/Headless/nodeuwp/nodeuwp.vcxproj
+++ b/Headless/nodeuwp/nodeuwp.vcxproj
@@ -270,12 +270,6 @@
       <DeploymentContent>true</DeploymentContent>
     </None>
     <None Include="nodeuwp_TemporaryKey.pfx" />
-    <None Include="node_modules.hash">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="node_modules.zip">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Headless/nodeuwp/nodeuwp.vcxproj
+++ b/Headless/nodeuwp/nodeuwp.vcxproj
@@ -270,12 +270,12 @@
       <DeploymentContent>true</DeploymentContent>
     </None>
     <None Include="nodeuwp_TemporaryKey.pfx" />
+    <None Include="node_modules.hash">
+      <DeploymentContent>true</DeploymentContent>
+    </None>
     <None Include="node_modules.zip">
       <DeploymentContent>true</DeploymentContent>
     </None>
-  </ItemGroup>
-  <ItemGroup>
-    <SDKReference Include="WindowsIoT, Version=10.0.10586.0" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">


### PR DESCRIPTION
With the change in https://github.com/munyirik/ntvsiot/commit/6d7f8b36e1ed66921dccd3493793aa1073c4beeb
The node_modules folder will be first compressed to a zip file before it's deployed.
This change adds the logic for extraction using zlib (one of nodes dependencies and a popular compression library).
I considered referencing a .NET component and basically do this on one line but I don't want to add a .NET Core
dependency and also need to include the assemblies within the package.